### PR TITLE
Artist alias pages support

### DIFF
--- a/src/userscripts/guessUnicodePunctuation.meta.js
+++ b/src/userscripts/guessUnicodePunctuation.meta.js
@@ -24,6 +24,7 @@ const metadata = {
 		`(${supportedEntities.join('|')})/create`,
 		'release/add', // release has no `create` route
 		`(${supportedEntities.join('|')})/[0-9a-f-]{36}/edit(_annotation)?`,
+		String.raw`artist/[0-9a-f-]{36}/(add-alias|alias\/\d+\/edit)`,
 		String.raw`artist/[0-9a-f-]{36}/credit/\d+/edit`,
 	].map(createMusicBrainzURLRule),
 };


### PR DESCRIPTION
I want to add:

```js
// @include      /^https?://((beta|test)\.)?musicbrainz\.org/artist/[0-9a-f-]{36}/(add-alias|alias\/\d+\/edit)(\?.+?)?(#.+?)?$/
```

Where slashes don't work if I don't protect them, at least inside this group.

I am not sure how this work, so let's see.
This PR works for artists, if it generates the include line I mention above.

Then I will add other entities than artist (but a quick try with release-group was not enough, I must change the text input field selector, apparently, as well, for other entities).

