### PR TITLE
Point to userscript homepage in edit note

### DIFF
--- a/src/editNote.js
+++ b/src/editNote.js
@@ -22,7 +22,8 @@ export function buildEditNote(...sections) {
 	sections = sections.map((section) => section.trim());
 
 	if (typeof GM_info !== 'undefined') {
-		sections.push(`${GM_info.script.name} (v${GM_info.script.version}, ${GM_info.script.namespace})`);
+		let homepage = GM_info.scriptMetaStr.match(/@homepageURL\s+(.+)/)[1];
+		sections.push(`${GM_info.script.name} (v${GM_info.script.version}, ${homepage})`);
 	}
 
 	// drop empty sections and keep only the last occurrence of duplicate sections


### PR DESCRIPTION
It may be better to direct editors to the specific homepage of the script being used rather than just the namespace, which isn't required to be a URL at all.

This change would affect your userscripts as well, so I understand if you don't want to merge this.

Fixes zabe40/musicbrainz-userscripts#20