### PR TITLE
Fix missing import and relationship type logic in Voice Actor Credits userscript (#50)

### DIFF
--- a/src/guessUnicodePunctuation.js
+++ b/src/guessUnicodePunctuation.js
@@ -1,4 +1,5 @@
 import { transformInputValues } from '@kellnerd/es-utils/dom/transformInputValues.js';
+import { transform } from '@kellnerd/es-utils/string/transform.js';
 import {
 	punctuationRules,
 	punctuationRulesForLanguage,

--- a/src/relationship-editor/voiceActorCredits.js
+++ b/src/relationship-editor/voiceActorCredits.js
@@ -1,14 +1,5 @@
-import {
-	closingDialog,
-	createBatchDialog,
-	createDialog,
-	creditTargetAs,
-} from './createDialog.js';
-import {
-	batchCreateRelationships,
-	createAttributeTree,
-	createRelationship,
-} from './createRelationship.js';
+import { closingDialog, createBatchDialog, createDialog, creditTargetAs } from './createDialog.js';
+import { batchCreateRelationships, createAttributeTree, createRelationship } from './createRelationship.js';
 import { entityCache } from '../entityCache.js';
 import { nameToMBIDCache } from '../nameToMBIDCache.js';
 import { fetchVoiceActors as fetchVoiceActorsFromDiscogs } from '../discogs/api.js';
@@ -25,7 +16,7 @@ import { discogsToMBIDCache } from '../discogs/entityMapping.js';
  * @returns {Promise<CreditParserLineStatus>}
  */
 export async function addVoiceActor(artistName, roleName, bypassCache = false) {
-	const artistMBID = !bypassCache && await nameToMBIDCache.get('artist', artistName);
+	const artistMBID = !bypassCache && (await nameToMBIDCache.get('artist', artistName));
 
 	/** @type {import('weight-balanced-tree').ImmutableTree<RecordingT> | null} */
 	const recordings = MB.relationshipEditor.state.selectedRecordings;
@@ -134,12 +125,14 @@ async function letUserSelectVoiceActor({ artistName, roleName, artistCredit, rec
  * Recordings to create the dialog for (fallback to release).
  */
 export async function createVoiceActorDialog({ artist, roleName, artistCredit, recordings } = {}) {
-	const vocalAttributes = [{
-		type: { gid: 'd3a36e62-a7c4-4eb9-839f-adfebe87ac12' }, // spoken vocals
-		credited_as: roleName,
-	}];
+	const vocalAttributes = [
+		{
+			type: { gid: 'd3a36e62-a7c4-4eb9-839f-adfebe87ac12' }, // spoken vocals
+			credited_as: roleName,
+		},
+	];
 
-	if (recordings) {
+	if (recordings && recordings.size > 0) {
 		await createBatchDialog(recordings, {
 			target: artist,
 			targetType: 'artist',
@@ -174,7 +167,7 @@ export function createVoiceActorRelationship({ artist, roleName, artistCredit, r
 		credited_as: roleName,
 	});
 
-	if (recordings) {
+	if (recordings && recordings.size > 0) {
 		batchCreateRelationships(recordings, artist, {
 			linkTypeID: 149, // performance -> performer -> vocals
 			entity0_credit: artistCredit,


### PR DESCRIPTION
This PR fixes two issues in the Voice Actor Credits userscript:

1. ReferenceError: `transform` is not defined  
   - Added the missing import for the `transform` function, which caused a runtime error when clicking the "Parse voice Actor credits" button.

2. Script always creates recording relationships  
   - Updated the logic to check for `recordings.size > 0` instead of just checking if `recordings` is truthy. This ensures the correct relationship type (recording or release) is created, depending on